### PR TITLE
Change minVer to struct in MddBootstrapInitialize examples

### DIFF
--- a/winapps-win32-src/content/mddbootstrap/nf-mddbootstrap-mddbootstrapinitialize.md
+++ b/winapps-win32-src/content/mddbootstrap/nf-mddbootstrap-mddbootstrapinitialize.md
@@ -105,7 +105,12 @@ Using C:
 #include <MddBootstrap.h>
 // ...
 
-HRESULT hr = MddBootstrapInitialize(WINDOWSAPPSDK_RELEASE_MAJORMINOR, WINDOWSAPPSDK_RELEASE_VERSION_TAG_W, WINDOWSAPPSDK_RUNTIME_VERSION_UINT64);
+HRESULT hr = MddBootstrapInitialize(
+    WINDOWSAPPSDK_RELEASE_MAJORMINOR,
+    WINDOWSAPPSDK_RELEASE_VERSION_TAG_W,
+    { WINDOWSAPPSDK_RUNTIME_VERSION_UINT64 }
+);
+
 if (FAILED(hr))
 {
     wprintf(L"Error 0x%X in Bootstrap initialization\n", hr);
@@ -118,7 +123,11 @@ Using C++:
 #include <MddBootstrap.h>
 // ...
 
-if (FAILED(MddBootstrapInitialize(Microsoft::WindowsAppSDK::Release::MajorMinor, Microsoft::WindowsAppSDK::Release::VersionTag, Microsoft::WindowsAppSDK::Runtime::UInt64))) {
+if (FAILED(MddBootstrapInitialize(
+    Microsoft::WindowsAppSDK::Release::MajorMinor,
+    Microsoft::WindowsAppSDK::Release::VersionTag, 
+    { Microsoft::WindowsAppSDK::Runtime::UInt64 }))) 
+{
     throw std::exception("Error in Bootstrap initialization");
 }
 ```


### PR DESCRIPTION
Previously the examples did not compile since a UINT64 was being passed as the third argument instead of being in a struct as per the definition of [PACKAGE_VERSION](https://docs.microsoft.com/en-us/windows/win32/api/appmodel/ns-appmodel-package_version). Also includes some minor formatting changes for readability.